### PR TITLE
Add usings based on source expressions

### DIFF
--- a/src/Mapgen.Analyzer/Extensions/MappingExtensionsTemplateEngine.cs
+++ b/src/Mapgen.Analyzer/Extensions/MappingExtensionsTemplateEngine.cs
@@ -36,7 +36,14 @@ public sealed class MappingExtensionsTemplateEngine
   {
     var builder = new StringBuilder();
 
-    foreach (var ns in _metadata.Usings)
+    // Ensure required system namespaces are always included
+    var requiredUsings = new[] { "System.Collections.Generic" };
+
+    var allUsings = requiredUsings
+      .Concat(_metadata.Usings)
+      .Distinct();
+
+    foreach (var ns in allUsings)
     {
       builder.AppendLine($"using {ns};");
     }
@@ -89,7 +96,6 @@ public sealed class MappingExtensionsTemplateEngine
 
   private const string MapperClassTemplate =
     """
-    using System.Collections.Generic;
 
     {{Usings}}
 

--- a/src/Mapgen.Analyzer/Mapper/MapperMethodTransformer.cs
+++ b/src/Mapgen.Analyzer/Mapper/MapperMethodTransformer.cs
@@ -36,6 +36,9 @@ public sealed class MapperMethodTransformer(SemanticModel semanticModel)
     AddDirectMappings(methodMetadata, ct);
     AddUnmappedPropertyDiagnostics(methodMetadata, ct);
 
+    // Detect required usings
+    DetectRequiredUsings(methodMetadata);
+
     return methodMetadata;
   }
 
@@ -368,5 +371,17 @@ public sealed class MapperMethodTransformer(SemanticModel semanticModel)
 
     // Case 3: No public constructors (very rare, but handle it)
     // No diagnostic needed - other error will occur during generation
+  }
+
+  private static void DetectRequiredUsings(MapperMethodMetadata methodMetadata)
+  {
+    // Check if any mapping uses immutable collection methods
+    var usesImmutableCollections = methodMetadata.Mappings.OfType<SourceMappingDescriptor>()
+      .Any(m => m.SourceExpression.Contains(".ToImmutable"));
+
+    if (usesImmutableCollections)
+    {
+      methodMetadata.AddRequiredUsing("System.Collections.Immutable");
+    }
   }
 }

--- a/src/Mapgen.Analyzer/Mapper/MappingDescriptors/BaseMappingDescriptor.cs
+++ b/src/Mapgen.Analyzer/Mapper/MappingDescriptors/BaseMappingDescriptor.cs
@@ -9,3 +9,14 @@ public abstract class BaseMappingDescriptor
     TargetPropertyName = targetPropertyName;
   }
 }
+
+public abstract class SourceMappingDescriptor : BaseMappingDescriptor
+{
+  public string SourceExpression { get; }
+
+  protected SourceMappingDescriptor(string targetPropertyName, string sourceExpression)
+    : base(targetPropertyName)
+  {
+    SourceExpression = sourceExpression;
+  }
+}

--- a/src/Mapgen.Analyzer/Mapper/MappingDescriptors/ConstructorArgumentDescriptor.cs
+++ b/src/Mapgen.Analyzer/Mapper/MappingDescriptors/ConstructorArgumentDescriptor.cs
@@ -3,18 +3,16 @@ namespace Mapgen.Analyzer.Mapper.MappingDescriptors;
 /// <summary>
 /// Represents a constructor argument mapping.
 /// </summary>
-public sealed class ConstructorArgumentDescriptor : BaseMappingDescriptor
+public sealed class ConstructorArgumentDescriptor : SourceMappingDescriptor
 {
-  public string SourceExpression { get; }
   public int ParameterPosition { get; }
 
   public ConstructorArgumentDescriptor(
     string targetPropertyName,
     string sourceExpression,
     int parameterPosition)
-    : base(targetPropertyName)
+    : base(targetPropertyName, sourceExpression)
   {
-    SourceExpression = sourceExpression;
     ParameterPosition = parameterPosition;
   }
 }

--- a/src/Mapgen.Analyzer/Mapper/MappingDescriptors/MappingDescriptor.cs
+++ b/src/Mapgen.Analyzer/Mapper/MappingDescriptors/MappingDescriptor.cs
@@ -1,13 +1,10 @@
 ﻿namespace Mapgen.Analyzer.Mapper.MappingDescriptors
 {
-  public sealed class MappingDescriptor : BaseMappingDescriptor
+  public sealed class MappingDescriptor : SourceMappingDescriptor
   {
-    public string SourceExpression { get; }
-
     public MappingDescriptor(string targetPropertyName, string sourceExpression)
-      : base(targetPropertyName)
+      : base(targetPropertyName, sourceExpression)
     {
-      SourceExpression = sourceExpression;
     }
   }
 }

--- a/src/Mapgen.Analyzer/Mapper/Metadata/MapperMethodMetadata.cs
+++ b/src/Mapgen.Analyzer/Mapper/Metadata/MapperMethodMetadata.cs
@@ -13,6 +13,7 @@ public sealed class MapperMethodMetadata
   private readonly List<BaseMappingDescriptor> _mappings = [];
   private readonly List<MapperDiagnostic> _diagnostics = [];
   private readonly List<IncludedMapperInfo> _includedMappers = [];
+  private readonly HashSet<string> _requiredUsings = [];
 
   public IMethodSymbol MethodSymbol { get; }
   public INamedTypeSymbol ReturnType => (INamedTypeSymbol)MethodSymbol.ReturnType;
@@ -31,6 +32,7 @@ public sealed class MapperMethodMetadata
   public IReadOnlyList<BaseMappingDescriptor> Mappings => _mappings;
   public IReadOnlyList<MapperDiagnostic> Diagnostics => _diagnostics;
   public IReadOnlyList<IncludedMapperInfo> IncludedMappers => _includedMappers;
+  public IReadOnlyCollection<string> RequiredUsings => _requiredUsings;
 
   public MapperMethodMetadata(IMethodSymbol methodSymbol)
   {
@@ -72,5 +74,10 @@ public sealed class MapperMethodMetadata
   public void SetUseEmptyConstructor(bool useEmptyConstructor)
   {
     UseEmptyConstructor = useEmptyConstructor;
+  }
+
+  public void AddRequiredUsing(string ns)
+  {
+    _requiredUsings.Add(ns);
   }
 }


### PR DESCRIPTION
Related to #3

Adding required usings on demand like:

```c#
using System.Collections.Immutable;
``` 

This PR is fixing the issue of having previously hardcoded System.Collections.Immutable in the template engine.
In the older versions of C# this namespace is not available which is causing the build error.

From now - the using of this namespace will be added when there is a call to any LINQ methods, responsible for casting the collection to immutable. For example here:

```c#
internal partial GarageDto ToGarageDto(Garage garage, Driver driver) {
      return new GarageDto(
        garage.Street,
        garage.City,
        garage.Number
      ) {
        Cars = garage.Cars.Select(car => _carMapper.ToCarDto(car, driver)).ToImmutableList(),
      };
    }
``` 