### PR TITLE
Fixed missing System.Linq. The using is added on demand

### DIFF
--- a/src/Mapgen.Analyzer/Mapper/MapperMethodTransformer.cs
+++ b/src/Mapgen.Analyzer/Mapper/MapperMethodTransformer.cs
@@ -375,13 +375,28 @@ public sealed class MapperMethodTransformer(SemanticModel semanticModel)
 
   private static void DetectRequiredUsings(MapperMethodMetadata methodMetadata)
   {
+    var sourceMappings = methodMetadata.Mappings.OfType<SourceMappingDescriptor>().ToList();
+
     // Check if any mapping uses immutable collection methods
-    var usesImmutableCollections = methodMetadata.Mappings.OfType<SourceMappingDescriptor>()
+    var usesImmutableCollections = sourceMappings
       .Any(m => m.SourceExpression.Contains(".ToImmutable"));
 
     if (usesImmutableCollections)
     {
       methodMetadata.AddRequiredUsing("System.Collections.Immutable");
+    }
+
+    // Check if any mapping uses LINQ methods (Select, Where, etc.)
+    var usesLinq = sourceMappings
+      .Any(m => m.SourceExpression.Contains(".Select(") ||
+                m.SourceExpression.Contains(".Where(") ||
+                m.SourceExpression.Contains(".ToList(") ||
+                m.SourceExpression.Contains(".ToArray(") ||
+                m.SourceExpression.Contains(".ToHashSet("));
+
+    if (usesLinq)
+    {
+      methodMetadata.AddRequiredUsing("System.Linq");
     }
   }
 }

--- a/src/Mapgen.Sample.Console/Mapgen.Sample.Console.csproj
+++ b/src/Mapgen.Sample.Console/Mapgen.Sample.Console.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <ImplicitUsings>disable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Mapgen.Sample.Console/Models/Garage.cs
+++ b/src/Mapgen.Sample.Console/Models/Garage.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Mapgen.Sample.Console.Models;
 
 public class Garage

--- a/src/Mapgen.Sample.Console/Program.cs
+++ b/src/Mapgen.Sample.Console/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
 
 using Mapgen.Sample.Console.Mappers;
 using Mapgen.Sample.Console.Models;

--- a/tests/Mapgen.Tests.Unit/Aliasing/Models/AliasMappingCases.cs
+++ b/tests/Mapgen.Tests.Unit/Aliasing/Models/AliasMappingCases.cs
@@ -1,3 +1,5 @@
+using System;
+
 using FluentAssertions;
 
 namespace Mapgen.Tests.Unit.Aliasing.Models;

--- a/tests/Mapgen.Tests.Unit/Aliasing/Models/Contract/Person.cs
+++ b/tests/Mapgen.Tests.Unit/Aliasing/Models/Contract/Person.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.Aliasing.Models.Contract;
 
 public class Person

--- a/tests/Mapgen.Tests.Unit/Aliasing/Models/Entity/Person.cs
+++ b/tests/Mapgen.Tests.Unit/Aliasing/Models/Entity/Person.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.Aliasing.Models.Entity;
 
 public class Person

--- a/tests/Mapgen.Tests.Unit/Inheritance/InheritanceMappingCases.cs
+++ b/tests/Mapgen.Tests.Unit/Inheritance/InheritanceMappingCases.cs
@@ -1,3 +1,5 @@
+using System;
+
 using FluentAssertions;
 
 using Mapgen.Tests.Unit.Inheritance.Models;

--- a/tests/Mapgen.Tests.Unit/Inheritance/Models/Car.cs
+++ b/tests/Mapgen.Tests.Unit/Inheritance/Models/Car.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.Inheritance.Models;
 
 public sealed class Car : Vehicle, IIdentifiable

--- a/tests/Mapgen.Tests.Unit/Inheritance/Models/CarDto.cs
+++ b/tests/Mapgen.Tests.Unit/Inheritance/Models/CarDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.Inheritance.Models;
 
 public sealed class CarDto : VehicleDto, IIdentifiable

--- a/tests/Mapgen.Tests.Unit/Inheritance/Models/IIdentifiable.cs
+++ b/tests/Mapgen.Tests.Unit/Inheritance/Models/IIdentifiable.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.Inheritance.Models;
 
 public interface IIdentifiable

--- a/tests/Mapgen.Tests.Unit/Mapgen.Tests.Unit.csproj
+++ b/tests/Mapgen.Tests.Unit/Mapgen.Tests.Unit.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <ImplicitUsings>disable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/CollectionMappingCases.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/CollectionMappingCases.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using Mapgen.Tests.Unit.MappingStrategies.CollectionMapping.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/Lead.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/Lead.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CollectionMapping.Models;
 
 public class Lead

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/LeadDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/LeadDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CollectionMapping.Models;
 
 public class LeadDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/Member.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/Member.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CollectionMapping.Models;
 
 public record Member

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/MemberDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/MemberDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CollectionMapping.Models;
 
 public record MemberDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/Team.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/Team.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CollectionMapping.Models;
 
 public class Team

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/TeamDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/Models/TeamDto.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CollectionMapping.Models;
 
 public class TeamDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/TeamMapper.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CollectionMapping/TeamMapper.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using Mapgen.Analyzer;
 using Mapgen.Tests.Unit.MappingStrategies.CollectionMapping.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/Models/Booking.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/Models/Booking.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.MultipleParameters.Models;
 
 public class Booking

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/Models/BookingDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/Models/BookingDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.MultipleParameters.Models;
 
 public class BookingDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/Models/Shipment.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/Models/Shipment.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.MultipleParameters.Models;
 
 public class Shipment

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/Models/ShipmentDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/Models/ShipmentDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.MultipleParameters.Models;
 
 public class ShipmentDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/MultipleParametersCases.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/MultipleParameters/MultipleParametersCases.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using Mapgen.Tests.Unit.MappingStrategies.CustomMapping.MultipleParameters.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/NestedProperty/Models/Employee.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/NestedProperty/Models/Employee.cs
@@ -1,4 +1,6 @@
-﻿namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.NestedProperty.Models;
+﻿using System;
+
+namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.NestedProperty.Models;
 
 public class Employee
 {

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/NestedProperty/Models/EmployeeDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/NestedProperty/Models/EmployeeDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.NestedProperty.Models;
 
 public class EmployeeDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/NestedProperty/NestedPropertyCases.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/NestedProperty/NestedPropertyCases.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using Mapgen.Tests.Unit.MappingStrategies.CustomMapping.NestedProperty.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/SimpleExpression/Models/Customer.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/SimpleExpression/Models/Customer.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.SimpleExpression.Models;
 
 public class Customer

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/SimpleExpression/Models/CustomerDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/SimpleExpression/Models/CustomerDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.CustomMapping.SimpleExpression.Models;
 
 public class CustomerDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/SimpleExpression/SimpleExpressionCases.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/CustomMapping/SimpleExpression/SimpleExpressionCases.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using Mapgen.Tests.Unit.MappingStrategies.CustomMapping.SimpleExpression.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ExactMatch/ExactMatchCases.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ExactMatch/ExactMatchCases.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using Mapgen.Tests.Unit.MappingStrategies.DirectMapping.ExactMatch.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ExactMatch/Models/Person.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ExactMatch/Models/Person.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.DirectMapping.ExactMatch.Models;
 
 public class Person

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ExactMatch/Models/PersonDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ExactMatch/Models/PersonDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.DirectMapping.ExactMatch.Models;
 
 public class PersonDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ImplicitConversion/ImplicitConversionCases.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ImplicitConversion/ImplicitConversionCases.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using Mapgen.Tests.Unit.MappingStrategies.DirectMapping.ImplicitConversion.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ImplicitConversion/Models/Contact.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ImplicitConversion/Models/Contact.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.DirectMapping.ImplicitConversion.Models;
 
 public class Contact

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ImplicitConversion/Models/ContactDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/DirectMapping/ImplicitConversion/Models/ContactDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.DirectMapping.ImplicitConversion.Models;
 
 public class ContactDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/IgnoreMapping/IgnoreMappingCases.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/IgnoreMapping/IgnoreMappingCases.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using Mapgen.Tests.Unit.MappingStrategies.IgnoreMapping.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/IgnoreMapping/Models/User.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/IgnoreMapping/Models/User.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.IgnoreMapping.Models;
 
 public class User

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/IgnoreMapping/Models/UserDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/IgnoreMapping/Models/UserDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.IgnoreMapping.Models;
 
 public class UserDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/IncludeMappersCases.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/IncludeMappersCases.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using Mapgen.Tests.Unit.MappingStrategies.IncludedMappers.Models;
 

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/Models/GamingStudio.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/Models/GamingStudio.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.IncludedMappers.Models;
 
 public class GamingStudio

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/Models/GamingStudioDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/Models/GamingStudioDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.IncludedMappers.Models;
 
 public class GamingStudioDto

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/Models/Publisher.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/Models/Publisher.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.IncludedMappers.Models;
 
 public class Publisher

--- a/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/Models/PublisherDto.cs
+++ b/tests/Mapgen.Tests.Unit/MappingStrategies/IncludedMappers/Models/PublisherDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.MappingStrategies.IncludedMappers.Models;
 
 public class PublisherDto

--- a/tests/Mapgen.Tests.Unit/PropertyAccessibility/Models/Order.cs
+++ b/tests/Mapgen.Tests.Unit/PropertyAccessibility/Models/Order.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.PropertyAccessibility.Models;
 
 /// <summary>

--- a/tests/Mapgen.Tests.Unit/PropertyAccessibility/Models/OrderDto.cs
+++ b/tests/Mapgen.Tests.Unit/PropertyAccessibility/Models/OrderDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.PropertyAccessibility.Models;
 
 /// <summary>

--- a/tests/Mapgen.Tests.Unit/PropertyAccessibility/Models/User.cs
+++ b/tests/Mapgen.Tests.Unit/PropertyAccessibility/Models/User.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.PropertyAccessibility.Models;
 
 /// <summary>

--- a/tests/Mapgen.Tests.Unit/PropertyAccessibility/Models/UserDto.cs
+++ b/tests/Mapgen.Tests.Unit/PropertyAccessibility/Models/UserDto.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mapgen.Tests.Unit.PropertyAccessibility.Models;
 
 /// <summary>

--- a/tests/Mapgen.Tests.Unit/PropertyAccessibility/PropertyAccessibilityCases.cs
+++ b/tests/Mapgen.Tests.Unit/PropertyAccessibility/PropertyAccessibilityCases.cs
@@ -1,3 +1,5 @@
+using System;
+
 using FluentAssertions;
 
 using Mapgen.Tests.Unit.PropertyAccessibility.Models;


### PR DESCRIPTION
Fixes the issue #1 

The using will be added to generated code when LINQ methods are used in source expressions.